### PR TITLE
Added italics for operator keywords

### DIFF
--- a/themes/new-moon.json
+++ b/themes/new-moon.json
@@ -83,7 +83,8 @@
 		},
 		{
 			"settings": {
-				"foreground": "#ffeea6"
+				"foreground": "#ffeea6",
+				"fontStyle": "italic"
 			},
 			"name": "Keywords",
 			"scope": "keyword,keyword.operator.expression.typeof,variable.language.this"
@@ -139,7 +140,8 @@
 		},
 		{
 			"settings": {
-				"foreground": "#ffeea6"
+				"foreground": "#ffeea6",
+				"fontStyle":"italic"
 			},
 			"name": "Storage",
 			"scope": "storage,support.function.construct.output.php,keyword.operator.new"


### PR DESCRIPTION
First: thank you for the theme. I found it originally as a Brackets theme, and this is a common edit I find myself making as it just helps to break up sections for me better. You can add it in or not, but I'd suggest giving it a try and seeing how you like it.